### PR TITLE
fix: should not modify function parameters

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,6 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm run ci
+  - npm run test
 
 build: off

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -85,7 +85,8 @@ class Cookies {
     return res ? res.value.toString() : undefined;
   }
 
-  set(name, value, opts) {
+  set(name, value, _opts) {
+    const opts = Object.assign({}, _opts);
     opts = encryptOrSigned(opts);
     value = value || '';
     if (!this.secure && opts.secure) {


### PR DESCRIPTION
如果[lib/Cookies.js](https://github.com/ggd543/egg-cookies/blob/ce7166b2235a68fc576910e42e3ea2f284215185/lib/cookies.js#L95)传进来的`opts` 参数中没有定义`secure`，那么会根据第一次的请求协议修改传进来的`opts`. 假如传进来的`opts`是单例，会影响后续的请求处理。

举例

```
// controller/index.js
global.options = {};
this.ctx.cookies('userId', uuid(),  global.options);
```

假设第一次是**https**， 则global.options会被注入`secure=true`, 当后续的请求是**http**，就会引发`'Cannot send secure cookie over unencrypted connection'`