### PR TITLE
fix: copy options

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,6 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm run ci
+  - npm run test
 
 build: off

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -48,7 +48,7 @@ class Cookies {
    * @return {String} value - cookie's value
    */
   get(name, opts) {
-    opts = encryptOrSigned(opts);
+    const signed = computeSigned(opts);
 
     const header = this.ctx.get('cookie');
     if (!header) return;
@@ -57,10 +57,10 @@ class Cookies {
     if (!match) return;
 
     let value = match[1];
-    if (!opts.encrypt && !opts.signed) return value;
+    if (!opts.encrypt && !signed) return value;
 
     // signed
-    if (opts.signed) {
+    if (signed) {
       const sigName = name + '.sig';
       const sigValue = this.get(sigName, { signed: false });
       if (!sigValue) return;
@@ -86,12 +86,11 @@ class Cookies {
   }
 
   set(name, value, opts) {
-    opts = encryptOrSigned(opts);
+    const signed = computeSigned(opts);
     value = value || '';
     if (!this.secure && opts.secure) {
       throw new Error('Cannot send secure cookie over unencrypted connection');
     }
-    if (opts.secure === undefined) opts.secure = this.secure;
 
     let headers = this.ctx.response.get('set-cookie') || [];
     if (!Array.isArray(headers)) headers = [ headers ];
@@ -107,10 +106,13 @@ class Cookies {
     }
 
     const cookie = new Cookie(name, value, opts);
+
+    if (opts.secure === undefined) cookie.attrs.secure = this.secure;
+
     headers = pushCookie(headers, cookie);
 
     // signed
-    if (opts.signed) {
+    if (signed) {
       cookie.value = value && this.keys.sign(cookie.toString());
       cookie.name += '.sig';
       headers = pushCookie(headers, cookie);
@@ -134,14 +136,13 @@ function getPattern(name) {
   return reg;
 }
 
-function encryptOrSigned(opts) {
+function computeSigned(opts) {
   // copy opts
-  opts = Object.assign({}, opts);
   // encrypt default to false, signed default to true.
   // disable singed when encrypt is true.
-  if (opts.encrypt) opts.signed = false;
-  if (opts.signed !== false) opts.signed = true;
-  return opts;
+  if (opts.encrypt) return false;
+  if (opts.signed !== false) return true;
+  return opts.signed;
 }
 
 function pushCookie(cookies, cookie) {

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -48,6 +48,7 @@ class Cookies {
    * @return {String} value - cookie's value
    */
   get(name, opts) {
+    opts = opts || {};
     const signed = computeSigned(opts);
 
     const header = this.ctx.get('cookie');
@@ -86,6 +87,7 @@ class Cookies {
   }
 
   set(name, value, opts) {
+    opts = opts || {};
     const signed = computeSigned(opts);
     value = value || '';
     if (!this.secure && opts.secure) {
@@ -137,7 +139,6 @@ function getPattern(name) {
 }
 
 function computeSigned(opts) {
-  // copy opts
   // encrypt default to false, signed default to true.
   // disable singed when encrypt is true.
   if (opts.encrypt) return false;

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -142,8 +142,7 @@ function computeSigned(opts) {
   // encrypt default to false, signed default to true.
   // disable singed when encrypt is true.
   if (opts.encrypt) return false;
-  if (opts.signed !== false) return true;
-  return opts.signed;
+  return opts.signed !== false;
 }
 
 function pushCookie(cookies, cookie) {

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -109,6 +109,7 @@ class Cookies {
 
     const cookie = new Cookie(name, value, opts);
 
+    // if user not set secure, reset secure to ctx.secure
     if (opts.secure === undefined) cookie.attrs.secure = this.secure;
 
     headers = pushCookie(headers, cookie);

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -109,7 +109,7 @@ class Cookies {
 
     const cookie = new Cookie(name, value, opts);
 
-    if (cookie.attrs.secure === undefined) cookie.attrs.secure = this.secure;
+    if (opts.secure === undefined) cookie.attrs.secure = this.secure;
 
     headers = pushCookie(headers, cookie);
 

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -109,7 +109,7 @@ class Cookies {
 
     const cookie = new Cookie(name, value, opts);
 
-    if (opts.secure === undefined) cookie.attrs.secure = this.secure;
+    if (cookie.attrs.secure === undefined) cookie.attrs.secure = this.secure;
 
     headers = pushCookie(headers, cookie);
 

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -135,7 +135,8 @@ function getPattern(name) {
 }
 
 function encryptOrSigned(opts) {
-  opts = opts || {};
+  // copy opts
+  opts = Object.assign({}, opts);
   // encrypt default to false, signed default to true.
   // disable singed when encrypt is true.
   if (opts.encrypt) opts.signed = false;

--- a/test/lib/cookies.test.js
+++ b/test/lib/cookies.test.js
@@ -203,4 +203,16 @@ describe('test/lib/cookies.test.js', () => {
     });
     cookies.set('foo', value);
   });
+
+  it('should opts do not modify', () => {
+    const cookies = Cookies({ secure: true });
+    const opts = {
+      signed: 1,
+    };
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === undefined);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+  });
 });


### PR DESCRIPTION
解决option为全局或缓存对象时，插件内部对options的错误变更

closes https://github.com/eggjs/egg-cookies/pull/8