### PR TITLE
test: Add unit tests for ts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-test/ts/report/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "eslint-config-egg"
+  "extends": "eslint-config-egg",
+  "parserOptions": {
+    "ecmaVersion": 2017
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,11 @@ declare namespace EggCookies {
 }
 
 declare class EggCookies {
+  
+  // For tests only, so we don't exclipt their real types
+  ctx: any;
+  constructor(ctx?: any, keys?: any);
+
   /**
    * Get the Egg's cookies by name with optional options.
    * @param name The Egg's cookie's unique name.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "utility": "^1.9.0"
   },
   "devDependencies": {
+    "@types/node": "^10.9.4",
     "autod": "^2.7.1",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.2",
@@ -19,9 +20,11 @@
     "egg-bin": "^1.7.0",
     "egg-ci": "^1.1.0",
     "eslint": "^3.10.2",
-    "eslint-config-egg": "^3.2.0",
+    "eslint-config-egg": "^7.0.0",
     "keygrip": "^1.0.1",
-    "power-assert": "^1.4.2"
+    "power-assert": "^1.4.2",
+    "ts-node": "^7.0.1",
+    "typescript": "^3.0.3"
   },
   "repository": {
     "type": "git",
@@ -30,16 +33,16 @@
   "homepage": "https://github.com/eggjs/egg-cookies",
   "author": "fengmk2 <fengmk2@gmail.com> (https://fengmk2.com)",
   "scripts": {
-    "test": "egg-bin test",
+    "test": "npm run lint -- --fix && egg-bin test",
     "cov": "egg-bin cov",
     "lint": "eslint index.js test",
     "ci": "npm run lint && npm run cov",
     "autod": "autod"
   },
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 8.0.0"
   },
   "ci": {
-    "version": "4, 6, 7"
+    "version": "8, 9"
   }
 }

--- a/test/fixtures/ts/cookiesTest.ts
+++ b/test/fixtures/ts/cookiesTest.ts
@@ -1,0 +1,77 @@
+import EggCookies = require('../../../');
+import { EventEmitter } from 'events';
+
+// Notice that this is a mocked function for 'ctx'
+// Because in a real env we cannot use this.cookies.ctx
+// and this is only for inner test.
+function CreateCookie(req?: any, options?: any): EggCookies {
+    options = options || {};
+    let keys = options.keys;
+    keys = keys === undefined ? ['key', 'keys'] : keys;
+    const ctx: any = { secure: options.secure };
+    ctx.app = new EventEmitter();
+    // Here we must use <any> to convert, otherwises
+    // it cannot pass compile successfully
+    ctx.request = (<any>Object).assign({
+        headers: {},
+        get(key) {
+            return this.headers[key];
+        }
+    }, req);
+
+    ctx.response = {
+        headers: {},
+        get(key) {
+            return this.headers[key];
+        },
+        set(key, value) {
+            this.headers[key] = value;
+        }
+    };
+
+    ctx.get = ctx.request.get.bind(ctx.request);
+    ctx.set = ctx.response.set.bind(ctx.response);
+    return new EggCookies(ctx, keys);
+}
+
+/**
+ * This test will define a JSON object called 'saveActualAnswer',
+ * and it will save some expected values, or actual values.
+ * Then the JSON object will be exported to compare with.
+ */
+const saveActualAnswer: any =
+{
+    test1: {},
+    test2: {},
+    test3: {}
+};
+
+// Test 1: should encrypt ok
+let cookies = CreateCookie();
+cookies.set('foo', 'bar', { encrypt: true });
+let cookie = cookies.ctx.response.headers['set-cookie'][0];
+cookies.ctx.request.headers.cookie = cookie;
+let value = cookies.get('foo', { encrypt: true });
+// Expect value is 'bar'.
+saveActualAnswer.test1.actualValue = value;
+// Expect value is -1.
+saveActualAnswer.test1.actualIndex = cookie.indexOf('bar');
+
+
+// Test 2: should signed work fine
+cookies = CreateCookie();
+cookies.set('foo', 'bar', { signed: true });
+cookie = cookies.ctx.response.headers['set-cookie'].join(';');
+cookies.ctx.request.headers.cookie = cookie;
+value = cookies.get('foo', { signed: true });
+// Expect value is 'bar'
+saveActualAnswer.test2.actualValue = value;
+
+// Test 3: should return undefined when header.cookie not exists
+cookies = CreateCookie();
+value = cookies.get('hello');
+// Expect value is undefined
+saveActualAnswer.test3.actualValue = value;
+
+// Finally export this directly for 'tsRun.test.js' to test with
+export = saveActualAnswer;

--- a/test/lib/ts.test.js
+++ b/test/lib/ts.test.js
@@ -6,11 +6,11 @@ describe('start running ts file under the ts folder...', () => {
 
   it('should run successfully and generate a json file to compare values', () => {
 
-        // This will dynamically add cookieTest and have a run
+    // This will dynamically add cookieTest and have a run
     require('ts-node').register({ typeCheck: true });
     const result = require('../fixtures/ts/cookiesTest');
 
-        // Check one by one
+    // Check one by one
     assert(result.test1.actualValue === 'bar');
     assert(result.test1.actualIndex === -1);
     assert(result.test2.actualValue === 'bar');

--- a/test/lib/tsRun.test.js
+++ b/test/lib/tsRun.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const assert = require('assert');
+
+describe('start running ts file under the ts folder...', () => {
+
+  it('should run successfully and generate a json file to compare values', () => {
+
+        // This will dynamically add cookieTest and have a run
+    require('ts-node').register({ typeCheck: true });
+    const result = require('../fixtures/ts/cookiesTest');
+
+        // Check one by one
+    assert(result.test1.actualValue === 'bar');
+    assert(result.test1.actualIndex === -1);
+    assert(result.test2.actualValue === 'bar');
+    assert(undefined === result.test3.actualValue);
+  });
+});


### PR DESCRIPTION
Ref: https://github.com/eggjs/egg-cookies/pull/11.

After a long discussion with @whxaxes, I used a ts-node to dynamically
run and fetch the result to do comparations. This test mainly covers:

1) Intellisenses：
![default](https://user-images.githubusercontent.com/40081831/45066884-0f000080-b0f3-11e8-86c0-cb4c571a1c39.PNG)

2) get/set methods.
