### PR TITLE
chore(typings): Remove 'ctx' in EggCookie'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,9 +61,7 @@ declare namespace EggCookies {
 }
 
 declare class EggCookies {
-  
-  // For tests only, so we don't exclipt their real types
-  ctx: any;
+
   constructor(ctx?: any, keys?: any);
 
   /**

--- a/test/fixtures/ts/cookiesTest.ts
+++ b/test/fixtures/ts/cookiesTest.ts
@@ -1,9 +1,8 @@
 import EggCookies = require('../../../');
 import { EventEmitter } from 'events';
 
-// Notice that this is a mocked function for 'ctx'
-// Because in a real env we cannot use this.cookies.ctx
-// and this is only for inner test.
+// This function creates a new instance of Cookie by mocking
+// a ctx there.
 function CreateCookie(req?: any, options?: any): EggCookies {
     options = options || {};
     let keys = options.keys;
@@ -14,17 +13,17 @@ function CreateCookie(req?: any, options?: any): EggCookies {
     // it cannot pass compile successfully
     ctx.request = (<any>Object).assign({
         headers: {},
-        get(key) {
+        get(key: any) {
             return this.headers[key];
         }
     }, req);
 
     ctx.response = {
         headers: {},
-        get(key) {
+        get(key: any) {
             return this.headers[key];
         },
-        set(key, value) {
+        set(key: any, value: any) {
             this.headers[key] = value;
         }
     };
@@ -43,14 +42,15 @@ const saveActualAnswer: any =
 {
     test1: {},
     test2: {},
-    test3: {}
+    test3: {},
+    test4: null
 };
 
 // Test 1: should encrypt ok
 let cookies = CreateCookie();
 cookies.set('foo', 'bar', { encrypt: true });
-let cookie = cookies.ctx.response.headers['set-cookie'][0];
-cookies.ctx.request.headers.cookie = cookie;
+let cookie = (<any>cookies).ctx.response.headers['set-cookie'][0];
+(<any>cookies).ctx.request.headers.cookie = cookie;
 let value = cookies.get('foo', { encrypt: true });
 // Expect value is 'bar'.
 saveActualAnswer.test1.actualValue = value;
@@ -61,8 +61,8 @@ saveActualAnswer.test1.actualIndex = cookie.indexOf('bar');
 // Test 2: should signed work fine
 cookies = CreateCookie();
 cookies.set('foo', 'bar', { signed: true });
-cookie = cookies.ctx.response.headers['set-cookie'].join(';');
-cookies.ctx.request.headers.cookie = cookie;
+cookie = (<any>cookies).ctx.response.headers['set-cookie'].join(';');
+(<any>cookies).ctx.request.headers.cookie = cookie;
 value = cookies.get('foo', { signed: true });
 // Expect value is 'bar'
 saveActualAnswer.test2.actualValue = value;
@@ -72,6 +72,32 @@ cookies = CreateCookie();
 value = cookies.get('hello');
 // Expect value is undefined
 saveActualAnswer.test3.actualValue = value;
+
+// Test 4: should emit cookieLimitExceed event in app when value\'s length exceed the limit
+cookies = CreateCookie();
+value = Buffer.allocUnsafe(4094).fill(49).toString();
+
+// Create a test4 with a promisible function and check the answer later
+// in the ts.test.js
+saveActualAnswer.test4 = new Promise((succ: any) => {
+    (<any>cookies).app.on('cookieLimitExceed', (params: any) => {
+        const test4: any = {};
+        // Expect value is 'foo'
+        test4.name = params.name;
+        // Except value is new Buffer(4094).fill(49).toString()
+        test4.value = params.value;
+        // Except value isn't null or undefined
+        test4.hasCtx = params.ctx;
+
+        setImmediate(() => {
+            // Except value is true
+            test4.match = (<any>cookies).ctx.response.headers['set-cookie'][0].match(/foo=1{4094};/);
+            succ(test4);
+        });
+    });
+    cookies.set('foo', value);
+});
+
 
 // Finally export this directly for 'tsRun.test.js' to test with
 export = saveActualAnswer;

--- a/test/lib/ts.test.js
+++ b/test/lib/ts.test.js
@@ -4,16 +4,38 @@ const assert = require('assert');
 
 describe('start running ts file under the ts folder...', () => {
 
-  it('should run successfully and generate a json file to compare values', () => {
+  it('should run successfully and generate a json file to compare values', done => {
 
     // This will dynamically add cookieTest and have a run
-    require('ts-node').register({ typeCheck: true });
+    // We must specify the compiler mode in compilerOptions, because
+    // 'Promise' starts since es2015
+    require('ts-node').register({
+      typeCheck: true,
+      compilerOptions: {
+        target: 'es2015',
+        module: 'commonjs',
+        strict: true,
+        lib: [
+          'es2015',
+        ],
+      },
+    });
     const result = require('../fixtures/ts/cookiesTest');
 
     // Check one by one
     assert(result.test1.actualValue === 'bar');
     assert(result.test1.actualIndex === -1);
     assert(result.test2.actualValue === 'bar');
-    assert(undefined === result.test3.actualValue);
+    assert(result.test3.actualValue === undefined);
+
+    // Use promisible's then to make a call back and check values
+    result.test4.then(result => {
+      assert(result.name === 'foo');
+      assert(result.value === Buffer.allocUnsafe(4094).fill(49).toString());
+      assert(result.hasCtx);
+      assert(result.match);
+      // Call back to tell that unit test is over
+      done();
+    });
   });
 });


### PR DESCRIPTION
1) The 'ctx' is exposed for test only instead of using it in the real
'egg' env. So we can remove this by cancelling the intellisense.
And this seems better.

2) Add a missing test to test what's happened when cookie's limit
exceeded.

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
