### PR TITLE
fix(typings): value of set method should support null type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare class EggCookies {
    * @param opts Optional. The options for cookie's setting.
    * @returns The current 'EggCookie' instance.
    */
-  set(name: string, value?: string, opts?: EggCookies.CookieSetOptions): this;
+  set(name: string, value?: string | null, opts?: EggCookies.CookieSetOptions): this;
 }
 
 export = EggCookies;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
Add `null` type support for `value` parameter of `EggCookies.set`