### PR TITLE
"keygrip" support using object and update crypto new method to resolve "(node:12008) [DEP0106] DeprecationWarning: crypto.createCipher is deprecated" warning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,21 @@ Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
 
 ##### Affected core subsystem(s)
 <!-- Provide affected core subsystem(s). -->
-
+compatible to the old version.
 
 ##### Description of change
 <!-- Provide a description of the change below this comment. -->
+resolve "(node:12008) [DEP0106] DeprecationWarning: crypto.createCipher is deprecated" warning when the node version gt than 11.0.0;
+update the keygrip support using object for iv params and keeping compatible with the old version
+enhance the keys checking：
+1、each of Keys is either object or string
+2、if the Key is object,key property must be privided with a string of 32 length
+3、if the Key is object,iv property must be privided with a string of 16 length
+eg:
+const key = new Keygrip([
+    'myoldversionkeys2',
+    'myoldversionkeys1',
+    { 
+        key: '12345678900987654321123456789009', 
+        iv: '1234567890098765' 
+    }]);

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ egg-cookies provide an alternative `encrypt` mode like `signed`. An encrypt cook
 
 ```js
 const Cookies = require('egg-cookies');
+const key = new Keygrip([
+    'myoldversionkeys2',
+    'myoldversionkeys1',
+    { 
+        key: '12345678900987654321123456789009', 
+        iv: '1234567890098765' 
+    }]);
 const cookies = new Cookies(ctx, keys[, defaultCookieOptions]);
 
 cookies.set('foo', 'bar', { encrypt: true });

--- a/lib/keygrip.js
+++ b/lib/keygrip.js
@@ -1,36 +1,55 @@
 'use strict';
 
+// because node v11.0.0 DEP0106: crypto.createCipher and crypto.createDecipher
+// so using crypto.createCipheriv crypto.createDecipheriv instead
+// and making compatible with lower version
+const process = require('process');
 const debug = require('debug')('egg-cookies:keygrip');
 const crypto = require('crypto');
 const assert = require('assert');
 const constantTimeCompare = require('scmp');
 
+const excNewCipherNodeVer = '11.0.0'; // node 11.0.0 version runtime using crypto.createCipheriv,crypto.createDecipheriv instead
 const replacer = {
   '/': '_',
   '+': '-',
   '=': '',
 };
 
+function isObject(val) {
+  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+}
+
 // patch from https://github.com/crypto-utils/keygrip
 
 class Keygrip {
   constructor(keys) {
     assert(Array.isArray(keys) && keys.length, 'keys must be provided and should be an array');
+    keys.forEach(key => {
+      assert(isObject(key) || typeof (key) === 'string', 'each of Keys is either object or string');
+      if (isObject(key)) {
+        assert(typeof (key.key) === 'string' && key.key.length === 32, 'if the Key is object,key property must be privided with a string of 32 length');
+        assert(typeof (key.iv) === 'string' && key.iv.length === 16, 'if the Key is object,iv property must be privided with a string of 16 length');
+      }
+    });
 
+    this.nodeVer = process.versions.node;
     this.keys = keys;
     this.hash = 'sha256';
     this.cipher = 'aes-256-cbc';
   }
 
   // encrypt a message
+
   encrypt(data, key) {
     key = key || this.keys[0];
-    const cipher = crypto.createCipher(this.cipher, key);
+    const cipher = process.versions.node >= excNewCipherNodeVer && isObject(key) ? crypto.createCipheriv(this.cipher, key.key, key.iv) : crypto.createCipher(this.cipher, key);
     return crypt(cipher, data);
   }
 
   // decrypt a single message
   // returns false on bad decrypts
+
   decrypt(data, key) {
     if (!key) {
       // decrypt every key
@@ -43,7 +62,7 @@ class Keygrip {
     }
 
     try {
-      const cipher = crypto.createDecipher(this.cipher, key);
+      const cipher = process.versions.node >= excNewCipherNodeVer && isObject(key) ? crypto.createDecipheriv(this.cipher, key.key, key.iv) : crypto.createDecipher(this.cipher, key);
       return crypt(cipher, data);
     } catch (err) {
       debug('crypt error', err.stack);
@@ -53,8 +72,8 @@ class Keygrip {
 
   sign(data, key) {
     // default to the first key
-    key = key || this.keys[0];
 
+    key = key || (isObject(this.keys[0]) ? this.keys[0].key : this.keys[0]);
     return crypto
       .createHmac(this.hash, key)
       .update(data)
@@ -65,8 +84,9 @@ class Keygrip {
   verify(data, digest) {
     const keys = this.keys;
     for (let i = 0; i < keys.length; i++) {
-      if (constantTimeCompare(Buffer.from(digest), Buffer.from(this.sign(data, keys[i])))) {
-        debug('data %s match key %s', data, keys[i]);
+      const key = isObject(keys[i]) ? keys[i].key : keys[i];
+      if (constantTimeCompare(Buffer.from(digest), Buffer.from(this.sign(data, key)))) {
+        debug('data %s match key %s', data, key);
         return i;
       }
     }

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -3,7 +3,6 @@
 const Cookies = require('..');
 const EventEmitter = require('events');
 
-
 module.exports = (req, options, defaultCookieOptions) => {
   options = options || {};
   let keys = options.keys;

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -3,6 +3,7 @@
 const Cookies = require('..');
 const EventEmitter = require('events');
 
+
 module.exports = (req, options, defaultCookieOptions) => {
   options = options || {};
   let keys = options.keys;

--- a/test/lib/keygrip.test.js
+++ b/test/lib/keygrip.test.js
@@ -8,6 +8,10 @@ describe('test/lib/keygrip.test.js', () => {
     assert(shouldThrow(() => new Keygrip()) === 'keys must be provided and should be an array');
     assert(shouldThrow(() => new Keygrip([])) === 'keys must be provided and should be an array');
     assert(shouldThrow(() => new Keygrip('hello')) === 'keys must be provided and should be an array');
+    assert(shouldThrow(() => new Keygrip([ '', 'afa', []])) === 'each of Keys is either object or string');
+    assert(shouldThrow(() => new Keygrip([[], { key: '11111111111111', iv: 'fafafa' }])) === 'each of Keys is either object or string');
+    assert(shouldThrow(() => new Keygrip([{ key: '11111111111111', iv: 'fafafa' }])) === 'if the Key is object,key property must be privided with a string of 32 length');
+    assert(shouldThrow(() => new Keygrip([{ key: '11111111111111111111111111111111', iv: 'fafa' }])) === 'if the Key is object,iv property must be privided with a string of 16 length');
   });
 
   it('should encrypt and decrypt success', () => {
@@ -19,6 +23,16 @@ describe('test/lib/keygrip.test.js', () => {
     assert(keygrip.decrypt(encrypted).index === 0);
     assert(newKeygrip.decrypt(encrypted).value.toString() === 'hello');
     assert(newKeygrip.decrypt(encrypted).index === 1);
+
+
+    const keygripX = new Keygrip([{ key: '12345678900987654321123456789009', iv: '1234567890098765' }, 'key' ]);
+    const newKeygripX = new Keygrip([{ key: '11111111111111110000000000000000', iv: '1111111177777777' }, { key: '12345678900987654321123456789009', iv: '1234567890098765' }]);
+    const encryptedX = keygripX.encrypt('hello');
+    console.log(encryptedX);
+    assert(keygripX.decrypt(encryptedX).value.toString() === 'hello');
+    assert(keygripX.decrypt(encryptedX).index === 0);
+    assert(newKeygripX.decrypt(encryptedX).value.toString() === 'hello');
+    assert(newKeygripX.decrypt(encryptedX).index === 1);
   });
 
   it('should decrypt error return false', () => {
@@ -38,6 +52,13 @@ describe('test/lib/keygrip.test.js', () => {
     const signed = keygrip.sign('hello');
     assert(keygrip.verify('hello', signed) === 0);
     assert(newKeygrip.verify('hello', signed) === 1);
+
+    const keygripX = new Keygrip([{ key: '12345678900987654321123456789009', iv: '1234567890098765' }, 'key' ]);
+    const newKeygripX = new Keygrip([{ key: '11111111111111110000000000000000', iv: '1111111177777777' }, { key: '12345678900987654321123456789009', iv: '1234567890098765' }]);
+
+    const signedX = keygripX.sign('hello');
+    assert(keygripX.verify('hello', signedX) === 0);
+    assert(newKeygripX.verify('hello', signedX) === 1);
   });
 
   it('should signed and verify failed return -1', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [√ ] `npm test` passes
- [ √] tests and/or benchmarks are included
- [√ ] documentation is changed or added
- [√ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
no effect

##### Description of change
<!-- Provide a description of the change below this comment. -->
resolve "(node:12008) [DEP0106] DeprecationWarning: crypto.createCipher is deprecated" warning when the node version gt than 11.0.0;
update the keygrip support using object for iv params and keeping compatible with the old version
enhance the keys checking：
1、each of Keys is either object or string
2、if the Key is object,key property must be privided with a string of 32 length
3、if the Key is object,iv property must be privided with a string of 16 length
eg:
const key = new Keygrip([
    'myoldversionkeys2',
    'myoldversionkeys1',
    { 
        key: '12345678900987654321123456789009', 
        iv: '1234567890098765' 
    }]);
