### PR TITLE
fix(SameSite): don't send SameSite=None on non-secure context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
-sudo: false
 language: node_js
 node_js:
-  - '4'
-  - '6'
   - '8'
   - '10'
   - '12'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: '4'
-    - nodejs_version: '6'
     - nodejs_version: '8'
     - nodejs_version: '10'
     - nodejs_version: '12'

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -114,8 +114,8 @@ class Cookies {
     // fixed SameSite=None: Known Incompatible Clients
     if (opts.sameSite && typeof opts.sameSite === 'string' && opts.sameSite.toLowerCase() === 'none') {
       const userAgent = this.ctx.get('user-agent');
-      if (userAgent && !this.isSameSiteNoneCompatible(userAgent)) {
-        // Incompatible clients, don't send SameSite=None property
+      if (!this.secure || (userAgent && !this.isSameSiteNoneCompatible(userAgent))) {
+        // Non-secure context or Incompatible clients, don't send SameSite=None property
         opts.sameSite = false;
       }
     }

--- a/test/lib/cookies.test.js
+++ b/test/lib/cookies.test.js
@@ -249,7 +249,7 @@ describe('test/lib/cookies.test.js', () => {
         headers: {
           'user-agent': ua,
         },
-      }, null, { sameSite: 'None' });
+      }, { secure: true }, { sameSite: 'None' });
       const opts = {
         signed: 1,
       };
@@ -259,7 +259,7 @@ describe('test/lib/cookies.test.js', () => {
       assert(opts.secure === undefined);
       assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
       for (const str of cookies.ctx.response.headers['set-cookie']) {
-        assert(str.includes('; path=/; httponly'));
+        assert(str.includes('; path=/; secure; httponly'));
       }
     }
   });
@@ -270,7 +270,7 @@ describe('test/lib/cookies.test.js', () => {
       headers: {
         'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36',
       },
-    }, null, { sameSite: 'None' });
+    }, { secure: true }, { sameSite: 'None' });
     const opts = {
       signed: 1,
     };
@@ -280,7 +280,7 @@ describe('test/lib/cookies.test.js', () => {
     assert(opts.secure === undefined);
     assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
     for (const str of cookies.ctx.response.headers['set-cookie']) {
-      assert(str.includes('; path=/; httponly'));
+      assert(str.includes('; path=/; secure; httponly'));
     }
   });
 
@@ -290,7 +290,7 @@ describe('test/lib/cookies.test.js', () => {
       headers: {
         'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3945.29 Safari/537.36',
       },
-    }, null, { sameSite: 'None' });
+    }, { secure: true }, { sameSite: 'None' });
     const opts = {
       signed: 1,
     };
@@ -300,7 +300,7 @@ describe('test/lib/cookies.test.js', () => {
     assert(opts.secure === undefined);
     assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
     for (const str of cookies.ctx.response.headers['set-cookie']) {
-      assert(str.includes('; path=/; samesite=none; httponly'));
+      assert(str.includes('; path=/; samesite=none; secure; httponly'));
     }
 
     cookies = Cookies({
@@ -308,14 +308,14 @@ describe('test/lib/cookies.test.js', () => {
       headers: {
         'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.3945.29 Safari/537.36',
       },
-    }, null, { sameSite: 'None' });
+    }, { secure: true }, { sameSite: 'None' });
     cookies.set('foo', 'hello', opts);
 
     assert(opts.signed === 1);
     assert(opts.secure === undefined);
     assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
     for (const str of cookies.ctx.response.headers['set-cookie']) {
-      assert(str.includes('; path=/; samesite=none; httponly'));
+      assert(str.includes('; path=/; samesite=none; secure; httponly'));
     }
   });
 
@@ -324,6 +324,27 @@ describe('test/lib/cookies.test.js', () => {
       secure: true,
       headers: {
         'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/66.6 Mobile/14A5297c Safari/602.1',
+      },
+    }, { secure: true }, { sameSite: 'none' });
+
+    const opts = {
+      signed: 1,
+    };
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === undefined);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+    for (const str of cookies.ctx.response.headers['set-cookie']) {
+      assert(str.includes('; path=/; samesite=none; secure; httponly'));
+    }
+  });
+
+  it('should not send SameSite=none property on non-secure context', () => {
+    const cookies = Cookies({
+      secure: false,
+      headers: {
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.3945.29 Safari/537.36',
       },
     }, null, { sameSite: 'none' });
     const opts = {
@@ -335,7 +356,7 @@ describe('test/lib/cookies.test.js', () => {
     assert(opts.secure === undefined);
     assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
     for (const str of cookies.ctx.response.headers['set-cookie']) {
-      assert(str.includes('; path=/; samesite=none; httponly'));
+      assert(str.includes('; path=/; httponly'));
     }
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
ignore `SameSite=None` prop in non-secure context(`ctx.secure` is equal to `false`).

##### Description of change
<!-- Provide a description of the change below this comment. -->
SameSite: filter SameSite=None in non-secure context.

> Chrome now only delivers cookies marked `SameSite=None` if they are also marked `Secure`, we should not mark cookies as `SameSite=None` in a non-secure context
ref: https://www.chromestatus.com/feature/5633521622188032

CI: upgrade ci configs.
- remove node v4 & v6 from ci environment list.
- remove deprecated key `sudo`. [reference](https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure)

