### PR TITLE
feat: deprecated crypto api

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,7 +35,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install Dependencies
-      run: npm i -g npminstall && npminstall
+      run: npm i -g npminstall@5 && npminstall
 
     - name: Continuous Integration
       run: npm run ci

--- a/lib/keygrip.js
+++ b/lib/keygrip.js
@@ -4,6 +4,8 @@ const debug = require('debug')('egg-cookies:keygrip');
 const crypto = require('crypto');
 const assert = require('assert');
 const constantTimeCompare = require('scmp');
+const EMPTY_IV = Buffer.alloc(16);
+const KEY_LEN = 32;
 
 const replacer = {
   '/': '_',
@@ -17,15 +19,15 @@ class Keygrip {
   constructor(keys) {
     assert(Array.isArray(keys) && keys.length, 'keys must be provided and should be an array');
 
-    this.keys = keys;
+    this.keys = keys.map(k => formatKey(k));
     this.hash = 'sha256';
     this.cipher = 'aes-256-cbc';
   }
 
   // encrypt a message
   encrypt(data, key) {
-    key = key || this.keys[0];
-    const cipher = crypto.createCipheriv(this.cipher, key);
+    key = key ? formatKey(key) : this.keys[0];
+    const cipher = crypto.createCipheriv(this.cipher, key, EMPTY_IV);
     return crypt(cipher, data);
   }
 
@@ -40,10 +42,12 @@ class Keygrip {
         if (value !== false) return { value, index: i };
       }
       return false;
+    } else {
+      key = formatKey(key);
     }
 
     try {
-      const cipher = crypto.createDecipher(this.cipher, key);
+      const cipher = crypto.createDecipheriv(this.cipher, key, EMPTY_IV, {  });
       return crypt(cipher, data);
     } catch (err) {
       debug('crypt error', err.stack);
@@ -78,6 +82,11 @@ function crypt(cipher, data) {
   const text = cipher.update(data, 'utf8');
   const pad = cipher.final();
   return Buffer.concat([ text, pad ]);
+}
+
+function formatKey(key) {
+  const keybuf = Buffer.from(key);
+  return Buffer.concat([keybuf, Buffer.alloc(KEY_LEN)], KEY_LEN);
 }
 
 module.exports = Keygrip;

--- a/lib/keygrip.js
+++ b/lib/keygrip.js
@@ -92,6 +92,7 @@ function keyToPassword(key) {
   }
 
   // Simulate EVP_BytesToKey.
+  // see https://github.com/nodejs/help/issues/1673#issuecomment-503222925
   const bytes = Buffer.alloc(KEY_LEN + IV_SIZE);
   let lastHash = null, nBytes = 0;
   while (nBytes < bytes.length) {

--- a/lib/keygrip.js
+++ b/lib/keygrip.js
@@ -4,8 +4,9 @@ const debug = require('debug')('egg-cookies:keygrip');
 const crypto = require('crypto');
 const assert = require('assert');
 const constantTimeCompare = require('scmp');
-const EMPTY_IV = Buffer.alloc(16);
 const KEY_LEN = 32;
+const IV_SIZE = 16;
+const passwordCache = new Map();
 
 const replacer = {
   '/': '_',
@@ -19,15 +20,17 @@ class Keygrip {
   constructor(keys) {
     assert(Array.isArray(keys) && keys.length, 'keys must be provided and should be an array');
 
-    this.keys = keys.map(k => formatKey(k));
+    this.keys = keys;
     this.hash = 'sha256';
     this.cipher = 'aes-256-cbc';
+    this.passwordCache = new Map();
   }
 
   // encrypt a message
   encrypt(data, key) {
-    key = key ? formatKey(key) : this.keys[0];
-    const cipher = crypto.createCipheriv(this.cipher, key, EMPTY_IV);
+    key = key || this.keys[0];
+    const password = keyToPassword(key);
+    const cipher = crypto.createCipheriv(this.cipher, password.key, password.iv);
     return crypt(cipher, data);
   }
 
@@ -38,18 +41,15 @@ class Keygrip {
       // decrypt every key
       const keys = this.keys;
       for (let i = 0; i < keys.length; i++) {
-        const value = this._decrypt(data, keys[i]);
+        const value = this.decrypt(data, keys[i]);
         if (value !== false) return { value, index: i };
       }
       return false;
     }
   
-    return this._decrypt(data, formatKey(key));
-  }
-
-  _decrypt(data, key) {
     try {
-      const cipher = crypto.createDecipheriv(this.cipher, formatKey(key), EMPTY_IV);
+      const password = keyToPassword(key);
+      const cipher = crypto.createDecipheriv(this.cipher, password.key, password.iv);
       return crypt(cipher, data);
     } catch (err) {
       debug('crypt error', err.stack);
@@ -86,10 +86,31 @@ function crypt(cipher, data) {
   return Buffer.concat([ text, pad ]);
 }
 
-function formatKey(key) {
-  const keybuf = Buffer.from(key);
-  if (keybuf.length === KEY_LEN) return keybuf;
-  return Buffer.concat([keybuf, Buffer.alloc(KEY_LEN)], KEY_LEN);
+function keyToPassword(key) {
+  if (passwordCache.has(key)) {
+    return passwordCache.get(key);
+  }
+
+  // Simulate EVP_BytesToKey.
+  const bytes = Buffer.alloc(KEY_LEN + IV_SIZE);
+  let lastHash = null, nBytes = 0;
+  while (nBytes < bytes.length) {
+    const hash = crypto.createHash('md5');
+    if (lastHash) hash.update(lastHash);
+    hash.update(key);
+    lastHash = hash.digest();
+    lastHash.copy(bytes, nBytes);
+    nBytes += lastHash.length;
+  }
+
+  // Use these for decryption.
+  const password = {
+    key: bytes.slice(0, KEY_LEN),
+    iv: bytes.slice(KEY_LEN, bytes.length)
+  };
+
+  passwordCache.set(key, password);
+  return password;
 }
 
 module.exports = Keygrip;

--- a/lib/keygrip.js
+++ b/lib/keygrip.js
@@ -45,7 +45,7 @@ class Keygrip {
       }
       return false;
     }
-  
+
     try {
       const password = keyToPassword(key);
       const cipher = crypto.createDecipheriv(this.cipher, password.key, password.iv);
@@ -93,7 +93,8 @@ function keyToPassword(key) {
   // Simulate EVP_BytesToKey.
   // see https://github.com/nodejs/help/issues/1673#issuecomment-503222925
   const bytes = Buffer.alloc(KEY_LEN + IV_SIZE);
-  let lastHash = null, nBytes = 0;
+  let lastHash = null,
+    nBytes = 0;
   while (nBytes < bytes.length) {
     const hash = crypto.createHash('md5');
     if (lastHash) hash.update(lastHash);
@@ -106,7 +107,7 @@ function keyToPassword(key) {
   // Use these for decryption.
   const password = {
     key: bytes.slice(0, KEY_LEN),
-    iv: bytes.slice(KEY_LEN, bytes.length)
+    iv: bytes.slice(KEY_LEN, bytes.length),
   };
 
   passwordCache.set(key, password);

--- a/lib/keygrip.js
+++ b/lib/keygrip.js
@@ -38,16 +38,18 @@ class Keygrip {
       // decrypt every key
       const keys = this.keys;
       for (let i = 0; i < keys.length; i++) {
-        const value = this.decrypt(data, keys[i]);
+        const value = this._decrypt(data, keys[i]);
         if (value !== false) return { value, index: i };
       }
       return false;
-    } else {
-      key = formatKey(key);
     }
+  
+    return this._decrypt(data, formatKey(key));
+  }
 
+  _decrypt(data, key) {
     try {
-      const cipher = crypto.createDecipheriv(this.cipher, key, EMPTY_IV, {  });
+      const cipher = crypto.createDecipheriv(this.cipher, formatKey(key), EMPTY_IV);
       return crypt(cipher, data);
     } catch (err) {
       debug('crypt error', err.stack);
@@ -86,6 +88,7 @@ function crypt(cipher, data) {
 
 function formatKey(key) {
   const keybuf = Buffer.from(key);
+  if (keybuf.length === KEY_LEN) return keybuf;
   return Buffer.concat([keybuf, Buffer.alloc(KEY_LEN)], KEY_LEN);
 }
 

--- a/lib/keygrip.js
+++ b/lib/keygrip.js
@@ -25,7 +25,7 @@ class Keygrip {
   // encrypt a message
   encrypt(data, key) {
     key = key || this.keys[0];
-    const cipher = crypto.createCipher(this.cipher, key);
+    const cipher = crypto.createCipheriv(this.cipher, key);
     return crypt(cipher, data);
   }
 

--- a/lib/keygrip.js
+++ b/lib/keygrip.js
@@ -23,7 +23,6 @@ class Keygrip {
     this.keys = keys;
     this.hash = 'sha256';
     this.cipher = 'aes-256-cbc';
-    this.passwordCache = new Map();
   }
 
   // encrypt a message

--- a/test/lib/keygrip.test.js
+++ b/test/lib/keygrip.test.js
@@ -2,6 +2,7 @@
 
 const Keygrip = require('../../lib/keygrip');
 const assert = require('assert');
+const crypto = require('crypto');
 
 describe('test/lib/keygrip.test.js', () => {
   it('should throw without keys', () => {
@@ -29,6 +30,18 @@ describe('test/lib/keygrip.test.js', () => {
     assert(keygrip.decrypt(encrypted).value.toString() === 'hello');
     assert(keygrip.decrypt(encrypted).index === 0);
     assert(newKeygrip.decrypt(encrypted) === false);
+  });
+
+  it('should decrypt key encrypted by createCipher without error', () => {
+    const keygrip = new Keygrip([ 'foo' ]);
+    const encrypted = keygrip.encrypt('hello');
+
+    const cipher = crypto.createCipher(keygrip.cipher, 'foo');
+    const text = cipher.update('hello', 'utf8');
+    const oldEncrypted = Buffer.concat([ text, cipher.final() ]);
+
+    assert(encrypted.toString('hex') === oldEncrypted.toString('hex'));
+    assert(keygrip.decrypt(oldEncrypted).value.toString('utf-8') === 'hello');
   });
 
   it('should signed and verify success', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

fix the warning: (node:74957) [DEP0106] DeprecationWarning: crypto.createCipher is deprecated.

##### Description of change
<!-- Provide a description of the change below this comment. -->
