### PR TITLE
feat: support function to set domain

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -20,15 +20,20 @@ const fieldContentRegExp = /^[\u0009\u0020-\u007e\u0080-\u00ff]+$/; // eslint-di
 const sameSiteRegExp = /^(?:none|lax|strict)$/i;
 
 class Cookie {
-  constructor(name, value, attrs) {
+  constructor(ctx, name, value, attrs) {
     assert(fieldContentRegExp.test(name), 'argument name is invalid');
     assert(!value || fieldContentRegExp.test(value), 'argument value is invalid');
 
+    this.ctx = ctx;
     this.name = name;
     this.value = value || '';
     this.attrs = mergeDefaultAttrs(attrs);
     assert(!this.attrs.path || fieldContentRegExp.test(this.attrs.path), 'argument option path is invalid');
-    assert(!this.attrs.domain || fieldContentRegExp.test(this.attrs.domain), 'argument option domain is invalid');
+    assert(!this.attrs.domain || typeof this.attrs.domain === 'string' || typeof this.attrs.domain === 'function', 'argument option domain is invalid');
+    if (typeof this.attrs.domain === 'function') {
+      this.attrs.domain = this.attrs.domain(this.ctx);
+    }
+    assert(fieldContentRegExp.test(this.attrs.domain), 'argument option domain is invalid');
     assert(!this.attrs.sameSite || this.attrs.sameSite === true || sameSiteRegExp.test(this.attrs.sameSite), 'argument option sameSite is invalid');
     if (!value) {
       this.attrs.expires = new Date(0);

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -121,7 +121,7 @@ class Cookies {
       }
     }
 
-    const cookie = new Cookie(name, value, opts);
+    const cookie = new Cookie(this.ctx, name, value, opts);
 
     // if user not set secure, reset secure to ctx.secure
     if (opts.secure === undefined) cookie.attrs.secure = this.secure;

--- a/test/lib/cookie.test.js
+++ b/test/lib/cookie.test.js
@@ -10,25 +10,25 @@ function assertExceptionCheck(expectedMsg) {
 }
 describe('test/lib/cookie.test.js', () => {
   it('create cookies contains invalid string error should throw', () => {
-    assert.throws(() => new Cookie('中文', 'value'), assertExceptionCheck('argument name is invalid'));
-    assert.throws(() => new Cookie('name', '中文'), assertExceptionCheck('argument value is invalid'));
-    assert.throws(() => new Cookie('name', 'value', { path: '中文' }), assertExceptionCheck('argument option path is invalid'));
-    assert.throws(() => new Cookie('name', 'value', { domain: '中文' }), assertExceptionCheck('argument option domain is invalid'));
+    assert.throws(() => new Cookie({}, '中文', 'value'), assertExceptionCheck('argument name is invalid'));
+    assert.throws(() => new Cookie({}, 'name', '中文'), assertExceptionCheck('argument value is invalid'));
+    assert.throws(() => new Cookie({}, 'name', 'value', { path: '中文' }), assertExceptionCheck('argument option path is invalid'));
+    assert.throws(() => new Cookie({}, 'name', 'value', { domain: '中文' }), assertExceptionCheck('argument option domain is invalid'));
   });
 
   it('set expires to 0 if value not present', () => {
-    assert(new Cookie('name', null).attrs.expires.getTime() === 0);
+    assert(new Cookie({}, 'name', null).attrs.expires.getTime() === 0);
   });
 
   describe('toString()', () => {
     it('return name=vaule', () => {
-      assert(new Cookie('name', 'value').toString() === 'name=value');
+      assert(new Cookie({}, 'name', 'value').toString() === 'name=value');
     });
   });
 
   describe('toHeader()', () => {
     it('return name=vaule;params', () => {
-      assert(new Cookie('name', 'value', {
+      assert(new Cookie({}, 'name', 'value', {
         secure: true,
         maxAge: 1000,
         domain: 'eggjs.org',
@@ -37,15 +37,27 @@ describe('test/lib/cookie.test.js', () => {
       }).toHeader().match(/^name=value; path=\/; max-age=1; expires=(.*?)GMT; domain=eggjs\.org; secure; httponly$/));
     });
 
+    it('set domain when domain is a function', () => {
+      assert(new Cookie({
+        hostname: 'eggjs.org',
+      }, 'name', 'value', {
+        secure: true,
+        maxAge: 1000,
+        domain: ctx => ctx.hostname,
+        path: '/',
+        httpOnly: true,
+      }).toHeader().match(/^name=value; path=\/; max-age=1; expires=(.*?)GMT; domain=eggjs\.org; secure; httponly$/));
+    });
+
     it('donnot set path when set path to null', () => {
-      const header = new Cookie('name', 'value', {
+      const header = new Cookie({}, 'name', 'value', {
         path: null,
       }).toHeader();
       assert(!header.match(/path=/));
     });
 
     it('donnot set httponly when set httpOnly to false', () => {
-      const header = new Cookie('name', 'value', {
+      const header = new Cookie({}, 'name', 'value', {
         httpOnly: false,
       }).toHeader();
       assert(!header.match(/httponly/));
@@ -55,7 +67,7 @@ describe('test/lib/cookie.test.js', () => {
   describe('maxAge', () => {
     it('maxAge overwrite expires', () => {
       const expires = new Date('2020-01-01');
-      let header = new Cookie('name', 'value', {
+      let header = new Cookie({}, 'name', 'value', {
         secure: true,
         expires,
         domain: 'eggjs.org',
@@ -63,7 +75,7 @@ describe('test/lib/cookie.test.js', () => {
         httpOnly: true,
       }).toHeader();
       assert(header.match(/expires=Wed, 01 Jan 2020 00:00:00 GMT/));
-      header = new Cookie('name', 'value', {
+      header = new Cookie({}, 'name', 'value', {
         secure: true,
         maxAge: 1000,
         expires,
@@ -75,7 +87,7 @@ describe('test/lib/cookie.test.js', () => {
     });
 
     it('ignore maxage NaN', () => {
-      const header = new Cookie('name', 'value', {
+      const header = new Cookie({}, 'name', 'value', {
         secure: true,
         maxAge: 'session',
         domain: 'eggjs.org',
@@ -88,7 +100,7 @@ describe('test/lib/cookie.test.js', () => {
 
     it('ignore maxage 0', () => {
       // In previous implementations, maxAge = 0 was considered unnecessary to set this header
-      const header = new Cookie('name', 'value', {
+      const header = new Cookie({}, 'name', 'value', {
         secure: true,
         maxAge: 0,
         domain: 'eggjs.org',
@@ -102,13 +114,13 @@ describe('test/lib/cookie.test.js', () => {
 
   describe('sameSite', () => {
     it('should default to false', () => {
-      const cookie = new Cookie('foo', 'bar');
+      const cookie = new Cookie({}, 'foo', 'bar');
       assert.equal(cookie.attrs.sameSite, false);
     });
 
     it('should throw on invalid value', () => {
       assert.throws(() => {
-        new Cookie('foo', 'bar', { sameSite: 'foo' });
+        new Cookie({}, 'foo', 'bar', { sameSite: 'foo' });
       }, /argument option sameSite is invalid/);
     });
 
@@ -116,7 +128,7 @@ describe('test/lib/cookie.test.js', () => {
       it('should not add "samesite" attribute in header', () => {
         const falsyValues = [ false, 0, '', null, undefined, NaN ];
         falsyValues.forEach(falsy => {
-          const cookie = new Cookie('foo', 'bar', { sameSite: falsy });
+          const cookie = new Cookie({}, 'foo', 'bar', { sameSite: falsy });
           assert.ok(Object.is(cookie.attrs.sameSite, falsy));
           assert.equal(cookie.toHeader(), 'foo=bar; path=/; httponly');
         });
@@ -125,7 +137,7 @@ describe('test/lib/cookie.test.js', () => {
 
     describe('when set to "true"', () => {
       it('should set "samesite=strict" attribute in header', () => {
-        const cookie = new Cookie('foo', 'bar', { sameSite: true });
+        const cookie = new Cookie({}, 'foo', 'bar', { sameSite: true });
         assert.equal(cookie.attrs.sameSite, true);
         assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=strict; httponly');
       });
@@ -134,11 +146,11 @@ describe('test/lib/cookie.test.js', () => {
     describe('when set to "none"', () => {
       it('should set "samesite=none" attribute in header', () => {
         {
-          const cookie = new Cookie('foo', 'bar', { sameSite: 'none' });
+          const cookie = new Cookie({}, 'foo', 'bar', { sameSite: 'none' });
           assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=none; httponly');
         }
         {
-          const cookie = new Cookie('foo', 'bar', { sameSite: 'None' });
+          const cookie = new Cookie({}, 'foo', 'bar', { sameSite: 'None' });
           assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=none; httponly');
         }
       });
@@ -147,11 +159,11 @@ describe('test/lib/cookie.test.js', () => {
     describe('when set to "lax"', () => {
       it('should set "samesite=lax" attribute in header', () => {
         {
-          const cookie = new Cookie('foo', 'bar', { sameSite: 'lax' });
+          const cookie = new Cookie({}, 'foo', 'bar', { sameSite: 'lax' });
           assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=lax; httponly');
         }
         {
-          const cookie = new Cookie('foo', 'bar', { sameSite: 'Lax' });
+          const cookie = new Cookie({}, 'foo', 'bar', { sameSite: 'Lax' });
           assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=lax; httponly');
         }
       });
@@ -160,11 +172,11 @@ describe('test/lib/cookie.test.js', () => {
     describe('when set to "strict"', () => {
       it('should set "samesite=strict" attribute in header', () => {
         {
-          const cookie = new Cookie('foo', 'bar', { sameSite: 'strict' });
+          const cookie = new Cookie({}, 'foo', 'bar', { sameSite: 'strict' });
           assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=strict; httponly');
         }
         {
-          const cookie = new Cookie('foo', 'bar', { sameSite: 'Strict' });
+          const cookie = new Cookie({}, 'foo', 'bar', { sameSite: 'Strict' });
           assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=strict; httponly');
         }
       });

--- a/test/lib/cookies.test.js
+++ b/test/lib/cookies.test.js
@@ -66,6 +66,17 @@ describe('test/lib/cookies.test.js', () => {
     assert(cookie.indexOf('secure') > 0);
   });
 
+  it('should work with domain ok, when domain is a function', () => {
+    const cookies = Cookies({
+      host: 'foo.com',
+    }, {
+      secure: true,
+    });
+    cookies.set('foo', 'bar', { encrypt: true, domain: ctx => ctx.request.host });
+    const cookie = cookies.ctx.response.headers['set-cookie'][0];
+    assert(cookie.indexOf('domain=foo.com') > 0);
+  });
+
   it('should signed work fine', () => {
     const cookies = Cookies();
     cookies.set('foo', 'bar', { signed: true });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

由于 set-cookies 时无法设置多 domain
![image](https://github.com/eggjs/egg-cookies/assets/16103358/ac29d2cb-2b7b-48a6-8eb2-299d5feb27d6)
故增加函数动态设置 domain 能力，当有多个不同域名访问时，可由用户自定义动态设置 domain
```
// config.default.js
exports.session = {
    domain: ctx => {
      return ctx.hostname === 'localhost' ? 'localhost' : '.lark.alipay.net';
    },
};
```
