### PR TITLE
feat: support ignoring secure error

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -57,6 +57,11 @@ export interface CookieSetOptions {
   * Encrypt the cookie's value or not
   */
   secure?: boolean;
+
+  /**
+  * Once `true` and secure set to `true`, ignore the secure error in a none-ssl environment.
+  */
+  ignoreSecureError?: boolean;
   /**
    * Is it signed or not.
    */

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -123,9 +123,12 @@ export class Cookies {
       ...opts,
     };
     const signed = computeSigned(opts);
+    const shouldIgnoreSecureError = opts && opts.ignoreSecureError;
     value = value || '';
-    if (!this.secure && opts.secure) {
-      throw new CookieError('Cannot send secure cookie over unencrypted connection');
+    if (!shouldIgnoreSecureError) {
+      if (!this.secure && opts.secure) {
+        throw new CookieError('Cannot send secure cookie over unencrypted connection');
+      }
     }
 
     let headers: string[] = this.ctx.response.get('set-cookie') || [];

--- a/test/cookie.test.ts
+++ b/test/cookie.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert';
 import { Cookie } from '../src/index.js';
 
 describe('test/cookie.test.ts', () => {
+
   it('create cookies contains invalid string error should throw', () => {
     assert.throws(() => new Cookie('中文', 'value'), /argument name is invalid/);
     assert.throws(() => new Cookie('name', '中文'), /argument value is invalid/);
@@ -19,6 +20,7 @@ describe('test/cookie.test.ts', () => {
     });
   });
 
+
   describe('toHeader()', () => {
     it('return name=value;params', () => {
       assert.match(new Cookie('name', 'value', {
@@ -28,6 +30,37 @@ describe('test/cookie.test.ts', () => {
         path: '/',
         httpOnly: true,
       }).toHeader(), /^name=value; path=\/; max-age=1; expires=(.*?)GMT; domain=eggjs\.org; secure; httponly$/);
+    });
+
+    it('no emit error once setting secure=true in none ssl environment', () => {
+      try {
+        new Cookie('name', 'value', {
+          secure: true,
+          ignoreSecureError: true,
+        });
+      } catch (error) {
+        assert.fail('There should not be any exception');
+      }
+    });
+
+    it('no emit error once setting secure=true in none ssl environment', () => {
+      const exceptionMessage = 'Cannot send secure cookie over unencrypted connection';
+      try {
+        new Cookie('name', 'value', {
+          secure: true,
+        });
+      } catch (error) {
+        assert.strictEqual((error as Error).message, exceptionMessage);
+      }
+
+      try {
+        new Cookie('name', 'value', {
+          secure: true,
+          ignoreSecureError: false,
+        });
+      } catch (error) {
+        assert.strictEqual((error as Error).message, exceptionMessage);
+      }
     });
 
     it('set domain when domain is a function', () => {


### PR DESCRIPTION
To address this:
https://github.com/eggjs/egg-cookies/issues/57

```
ctx.cookies.set('a', 'abc', { httpOnly: true, secure: true, ignoreSecureError: true })
```

Foster following architechture:
alb -> server1 -> nginx -proxy-> http://localhost:7002/
      -> server2 -> nginx -proxy-> http://localhost:7002/

closes https://github.com/eggjs/egg-cookies/issues/57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional property `ignoreSecureError` for enhanced cookie management, allowing secure cookies to be set in non-SSL environments.
- **Bug Fixes**
	- Added tests to ensure proper error handling when setting secure cookies in non-SSL environments based on the `ignoreSecureError` property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->